### PR TITLE
Refresh Slack invite link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/rook-io/shared_invite/zt-23hi9wqet-BUFB0AoXbxRPILbAxdfFiA" />
+        <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/rook-io/shared_invite/zt-2bgp7shhs-vIcrTOR_DTpsfLvgVIYWnw" />
     </head>
     <body>
-        <p><a href="">Redirecting you to https://join.slack.com/t/rook-io/shared_invite/zt-23hi9wqet-BUFB0AoXbxRPILbAxdfFiA</a></p>
+        <p><a href="">Redirecting you to https://join.slack.com/t/rook-io/shared_invite/zt-2bgp7shhs-vIcrTOR_DTpsfLvgVIYWnw</a></p>
     </body>
 </html>


### PR DESCRIPTION
This PR simply updates the Slack invite link to a fresh one because while they do not expire in time, they do expire after 400 invitations accepted.  Therefore, we're just staying ahead of that here and refreshing the link with a new one that has 400/400 invites left 😂 

Confirmation of link settings from https://rook-io.slack.com/admin/invites:
![Screenshot 2024-01-23 at 9 41 31 AM](https://github.com/rook/slack.rook.io/assets/4313439/21549141-acf4-4370-a7b1-3ab915fc5c46)
